### PR TITLE
Modify the dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,13 +30,13 @@ git-filter-repo==2.47.0
 graphviz==0.20.3
 greenlet==3.1.1
 griffe==1.5.4
-h11==0.16.0
+h11==0.14.0
 h2==4.3.0
-hpack==4.0.0
+hpack==4.1.0
 httpcore==1.0.7
 httpx==0.28.1
 humanize==4.11.0
-hyperframe==6.0.1
+hyperframe==6.1.0
 idna==3.10
 importlib_metadata==8.5.0
 Jinja2==3.1.6
@@ -95,7 +95,7 @@ shellingham==1.5.4
 six==1.17.0
 sniffio==1.3.1
 SQLAlchemy==2.0.36
-starlette==0.47.2
+starlette==0.41.3
 text-unidecode==1.3
 time-machine==2.16.0
 toml==0.10.2


### PR DESCRIPTION
Some indirects were updated by dependabot, but we are currently limited by FastAPI’s dependency constraints, so we cannot use the most current versions of h11 or starlette.