### PR TITLE
Republish the site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,16 +1,12 @@
 site_name: Central Docs
 repo_url: https://github.com/city-of-saint-louis/central-docs
 repo_name: /central-docs
-# edit_uri: edit/main/docs/
 theme: 
   name: material
   favicon: assets/bookshelf.svg
   icon:
     logo: material/bookshelf
     repo: fontawesome/brands/github
-  #   edit: material/pencil
-  # features:
-  #   - content.action.edit
 markdown_extensions:
   - admonition
   - pymdownx.details


### PR DESCRIPTION
The central-docs site has now been published to gh pages, but mkdocs/material still has some cached links that point to the old dynamic url.

This also removes the commented out "edit on gh" sections of the mkdocs.yml file.