### PR TITLE
Use directory urls

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,3 +16,4 @@ nav:
   - Home: index.md
   - Branching: branching.md
   - Workflow: workflow.md
+use_directory_urls: false


### PR DESCRIPTION
added use_directory_urls: false to mkdocs yaml, which should fix the broken "home" links