### PR TITLE
Update urllib3 to v 2.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,5 @@ PyYAML==6.0.3
 pyyaml_env_tag==1.1
 requests==2.32.5
 six==1.17.0
-urllib3==2.5.0
+urllib3==2.6.0
 watchdog==6.0.0


### PR DESCRIPTION
Addresses dependabot alerts:
- https://github.com/city-of-saint-louis/central-docs/security/dependabot/10
- https://github.com/city-of-saint-louis/central-docs/security/dependabot/11